### PR TITLE
feat: implement college selection in onboarding, groups/leaderboards …

### DIFF
--- a/app/api/colleges/route.ts
+++ b/app/api/colleges/route.ts
@@ -1,18 +1,52 @@
 import { NextResponse } from "next/server"
-import { createClient } from "@/lib/supabase/server"
+import { createServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
 
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url)
-  const q = (searchParams.get("q") || "").trim()
-  const supabase = await createClient()
+export async function GET() {
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies },
+  )
 
-  let query = supabase.from("colleges").select("id, name, country").eq("country", "India").limit(50)
-  if (q) {
-    // ilike search for convenience
-    query = query.ilike("name", `%${q}%`)
-  }
-  const { data, error } = await query
+  const { data, error } = await supabase
+    .from("colleges")
+    .select("id, name")
+    .order("name")
+
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
 
-  return NextResponse.json({ colleges: data ?? [] })
+  return NextResponse.json({ colleges: data })
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}))
+  const name = body?.name as string | undefined
+  if (!name?.trim()) return NextResponse.json({ error: "College name required" }, { status: 400 })
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies },
+  )
+
+  // Check if exists
+  const { data: existing } = await supabase
+    .from("colleges")
+    .select("id")
+    .eq("name", name.trim())
+    .maybeSingle()
+
+  if (existing) return NextResponse.json({ id: existing.id })
+
+  // Create new
+  const { data, error } = await supabase
+    .from("colleges")
+    .insert({ name: name.trim() })
+    .select("id")
+    .single()
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  return NextResponse.json({ id: data.id })
 }

--- a/app/api/groups/[id]/invite/route.ts
+++ b/app/api/groups/[id]/invite/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server"
+import { createServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
+import { randomUUID } from "crypto"
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const groupId = params.id
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: await cookies() }
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  // Check if user is member of group
+  const { data: membership } = await supabase
+    .from("group_memberships")
+    .select("role")
+    .eq("group_id", groupId)
+    .eq("user_id", user.id)
+    .single()
+
+  if (!membership) return NextResponse.json({ error: "Not a member" }, { status: 403 })
+
+  // Generate invite code
+  const inviteCode = randomUUID()
+
+  // Store in DB (assume invite_codes table or add to groups)
+  // For simplicity, add to groups table
+  const { error } = await supabase
+    .from("groups")
+    .update({ invite_code: inviteCode })
+    .eq("id", groupId)
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  const inviteLink = `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/groups/join/${inviteCode}`
+
+  return NextResponse.json({ link: inviteLink, code: inviteCode })
+}
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const groupId = params.id
+  const body = await req.json().catch(() => ({}))
+  const inviteCode = body?.code as string | undefined
+  if (!inviteCode) return NextResponse.json({ error: "Invite code required" }, { status: 400 })
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: await cookies() },
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  // Verify code
+  const { data: group } = await supabase
+    .from("groups")
+    .select("college_id, invite_code")
+    .eq("id", groupId)
+    .eq("invite_code", inviteCode)
+    .single()
+
+  if (!group) return NextResponse.json({ error: "Invalid invite code" }, { status: 400 })
+
+  // Check user's college
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("college_id")
+    .eq("id", user.id)
+    .single()
+
+  if (!profile?.college_id || profile.college_id !== group.college_id) {
+    return NextResponse.json({ error: "College mismatch" }, { status: 400 })
+  }
+
+  // Check member count
+  const { count } = await supabase
+    .from("group_memberships")
+    .select("*", { count: "exact", head: true })
+    .eq("group_id", groupId)
+
+  if (count && count >= 3) return NextResponse.json({ error: "Group is full" }, { status: 400 })
+
+  // Add member
+  const { error } = await supabase
+    .from("group_memberships")
+    .upsert({
+      group_id: groupId,
+      user_id: user.id,
+      role: "member"
+    }, { onConflict: "group_id,user_id" })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/groups/add-member/route.ts
+++ b/app/api/groups/add-member/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server"
+import { createServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}))
+  const groupId = body?.groupId as string | undefined
+  const targetHandle = body?.handle as string | undefined
+  if (!groupId || !targetHandle?.trim()) return NextResponse.json({ error: "groupId and handle required" }, { status: 400 })
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: await cookies() },
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  // Check if user is admin/moderator of group
+  const { data: membership } = await supabase
+    .from("group_memberships")
+    .select("role")
+    .eq("group_id", groupId)
+    .eq("user_id", user.id)
+    .single()
+
+  if (!membership || !["admin", "moderator"].includes(membership.role)) {
+    return NextResponse.json({ error: "Not authorized to add members" }, { status: 403 })
+  }
+
+  // Get group college
+  const { data: group } = await supabase
+    .from("groups")
+    .select("college_id")
+    .eq("id", groupId)
+    .single()
+
+  if (!group) return NextResponse.json({ error: "Group not found" }, { status: 404 })
+
+  // Find target user by handle
+  const { data: targetProfile } = await supabase
+    .from("profiles")
+    .select("id, college_id")
+    .eq("cf_handles.handle", targetHandle.trim())
+    .single()
+
+  if (!targetProfile) return NextResponse.json({ error: "User not found or not verified" }, { status: 404 })
+
+  // Check college match
+  if (targetProfile.college_id !== group.college_id) {
+    return NextResponse.json({ error: "This user belongs to a different college." }, { status: 400 })
+  }
+
+  // Check member count < 3
+  const { count } = await supabase
+    .from("group_memberships")
+    .select("*", { count: "exact", head: true })
+    .eq("group_id", groupId)
+
+  if (count && count >= 3) return NextResponse.json({ error: "Group is full (max 3 members)" }, { status: 400 })
+
+  // Add member
+  const { error } = await supabase
+    .from("group_memberships")
+    .upsert({
+      group_id: groupId,
+      user_id: targetProfile.id,
+      role: "member"
+    }, { onConflict: "group_id,user_id" })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/groups/create/route.ts
+++ b/app/api/groups/create/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server"
+import { createServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}))
+  const name = body?.name as string | undefined
+  if (!name?.trim()) return NextResponse.json({ error: "Group name required" }, { status: 400 })
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: await cookies() },
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  // Check if user has college set
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("college_id")
+    .eq("id", user.id)
+    .single()
+
+  if (!profile?.college_id) return NextResponse.json({ error: "College not set" }, { status: 400 })
+
+  // Create group
+  const { data, error } = await supabase
+    .from("groups")
+    .insert({
+      name: name.trim(),
+      type: "college",
+      college_id: profile.college_id,
+      created_by: user.id,
+    })
+    .select("id")
+    .single()
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  // Add creator as admin
+  const { error: memErr } = await supabase
+    .from("group_memberships")
+    .insert({
+      group_id: data.id,
+      user_id: user.id,
+      role: "admin"
+    })
+
+  if (memErr) return NextResponse.json({ error: memErr.message }, { status: 500 })
+
+  return NextResponse.json({ id: data.id })
+}

--- a/app/api/leaderboards/route.ts
+++ b/app/api/leaderboards/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { getUserRatings } from "@/lib/codeforces-api";
+
+// --- Types ---
+interface CFHandle {
+  handle: string;
+  rating: number;
+}
+
+interface ProfileData {
+  id: string;
+  full_name: string | null;
+  cf_handles: CFHandle[];
+  college_id: string | null;
+  colleges: { name: string } | null;
+}
+
+type RatingMap = Record<string, { rating: number }>;
+
+// --- Utils: Fetch ratings in parallel ---
+// This function is now imported from "@/lib/codeforces-api"
+
+// --- API Handler ---
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const type = url.searchParams.get("type") as "same" | "all"; // same | all
+    const ratingMin = parseInt(url.searchParams.get("ratingMin") || "0");
+    const ratingMax = parseInt(url.searchParams.get("ratingMax") || "4000");
+    const limit = parseInt(url.searchParams.get("limit") || "50");
+    const offset = parseInt(url.searchParams.get("offset") || "0");
+
+    if (!["same", "all"].includes(type)) {
+      return NextResponse.json({ error: "Invalid type" }, { status: 400 });
+    }
+
+    // --- Supabase client ---
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { cookies: await cookies() }
+    );
+
+    // --- Auth check ---
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // --- Build query ---
+    let query = supabase
+      .from("profiles")
+      .select(
+        `
+        id,
+        full_name,
+        cf_handles!inner(handle, rating),
+        college_id,
+        colleges(name)
+      `
+      )
+      .not("cf_handles.handle", "is", null)
+      .gte("cf_handles.rating", ratingMin)
+      .lte("cf_handles.rating", ratingMax)
+      .order("cf_handles.rating", { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (type === "same") {
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("college_id")
+        .eq("id", user.id)
+        .single();
+
+      if (!profile?.college_id) {
+        return NextResponse.json({ error: "No college set" }, { status: 400 });
+      }
+
+      query = query.eq("college_id", profile.college_id);
+    }
+
+    // --- Execute query ---
+    const { data: profiles, error } = (await query) as {
+      data: ProfileData[] | null;
+      error: any;
+    };
+
+    if (error || !profiles) {
+      return NextResponse.json(
+        { error: error?.message || "Failed to fetch profiles" },
+        { status: 500 }
+      );
+    }
+
+    // --- Extract handles & fetch live ratings ---
+    const allHandles = profiles
+      .map((p) => p.cf_handles.map((h) => h.handle))
+      .flat()
+      .filter(Boolean);
+
+    const ratings = await getUserRatings(allHandles);
+
+    // --- Build leaderboard ---
+    const leaderboard = profiles.map((p: ProfileData, index: number) => {
+      // Pick highest rated handle
+      const mainHandle = p.cf_handles.reduce(
+        (best, h) => (h.rating > best.rating ? h : best),
+        p.cf_handles[0]
+      );
+
+      const handle = mainHandle?.handle || "Unknown";
+      const liveRating =
+        ratings[handle]?.rating ?? mainHandle?.rating ?? 0;
+
+      return {
+        id: p.id,
+        name: p.full_name || handle,
+        handle,
+        rating: liveRating,
+        college: p.colleges?.name || "Unknown",
+        rank: offset + index + 1,
+      };
+    });
+
+    return NextResponse.json({ leaderboard });
+  } catch (err: any) {
+    return NextResponse.json(
+      { error: err?.message || "Unexpected server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -169,7 +169,7 @@ export default function GroupsPage() {
     <main className="mx-auto max-w-6xl px-4 py-10">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-3xl font-bold">Groups</h1>
+          <h1 className="text-3xl font-bold">Groups / Leaderboards</h1>
           <p className="text-muted-foreground mt-1">
             Join groups to compete with friends and classmates
           </p>

--- a/app/onboarding/college-step.tsx
+++ b/app/onboarding/college-step.tsx
@@ -1,0 +1,166 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Badge } from "@/components/ui/badge"
+import { useToast } from "@/hooks/use-toast"
+import { GraduationCap, Plus } from "lucide-react"
+
+interface College {
+  id: string
+  name: string
+}
+
+interface CollegeStepProps {
+  onComplete: () => void
+}
+
+export function CollegeStep({ onComplete }: CollegeStepProps) {
+  const [colleges, setColleges] = useState<College[]>([])
+  const [selectedCollege, setSelectedCollege] = useState<string>("")
+  const [customCollege, setCustomCollege] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [showCustom, setShowCustom] = useState(false)
+  const { toast } = useToast()
+
+  useEffect(() => {
+    fetchColleges()
+  }, [])
+
+  async function fetchColleges() {
+    try {
+      const res = await fetch("/api/colleges")
+      const data = await res.json()
+      if (res.ok) setColleges(data.colleges || [])
+    } catch (error) {
+      console.error("Failed to fetch colleges:", error)
+    }
+  }
+
+  async function handleCollegeSubmit() {
+    const collegeName = showCustom ? customCollege.trim() : selectedCollege
+    if (!collegeName) return
+
+    setIsLoading(true)
+    try {
+      let collegeId = selectedCollege
+
+      if (showCustom) {
+        // Create new college
+        const res = await fetch("/api/colleges", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: collegeName }),
+        })
+        const data = await res.json()
+        if (!res.ok) throw new Error(data.error)
+        collegeId = data.id
+      }
+
+      // Join college group
+      const res = await fetch("/api/groups/join-college", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ collegeId }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error)
+
+      toast({ title: "College Set!", description: `Joined ${collegeName} group` })
+      onComplete()
+    } catch (error: any) {
+      toast({ title: "Error", description: error.message, variant: "destructive" })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-500/20">
+          <GraduationCap className="h-6 w-6 text-blue-400" />
+        </div>
+        <h2 className="text-2xl font-bold">Which college are you from? 🎓</h2>
+        <p className="text-muted-foreground mt-2">
+          Join your college community to compete with classmates
+        </p>
+      </div>
+
+      <Card className="border-blue-500/20 bg-card/50 backdrop-blur">
+        <CardHeader>
+          <CardTitle>Select Your College</CardTitle>
+          <CardDescription>
+            Choose from the list or add your college if it's not there
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!showCustom ? (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="college">College</Label>
+                <Select value={selectedCollege} onValueChange={setSelectedCollege}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select your college" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {colleges.map((college) => (
+                      <SelectItem key={college.id} value={college.id}>
+                        {college.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="text-center">
+                <Button
+                  variant="ghost"
+                  onClick={() => setShowCustom(true)}
+                  className="text-sm"
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  My college isn't listed
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="custom-college">College Name</Label>
+                <Input
+                  id="custom-college"
+                  placeholder="Enter your college name"
+                  value={customCollege}
+                  onChange={(e) => setCustomCollege(e.target.value)}
+                />
+              </div>
+
+              <div className="text-center">
+                <Button
+                  variant="ghost"
+                  onClick={() => setShowCustom(false)}
+                  className="text-sm"
+                >
+                  ← Back to list
+                </Button>
+              </div>
+            </>
+          )}
+
+          <Button
+            onClick={handleCollegeSubmit}
+            disabled={isLoading || (!selectedCollege && !customCollege.trim())}
+            className="w-full"
+          >
+            {isLoading ? "Setting up..." : "Continue"}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/leaderboards/global-leaderboard.tsx
+++ b/components/leaderboards/global-leaderboard.tsx
@@ -1,0 +1,208 @@
+"use client"
+
+import { useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Slider } from "@/components/ui/slider"
+import { Trophy, Medal, Award, TrendingUp, Users } from "lucide-react"
+import useSWR from "swr"
+
+interface LeaderboardEntry {
+  id: string
+  name: string
+  handle: string
+  rating: number
+  college: string
+  rank: number
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json())
+
+export function GlobalLeaderboard() {
+  const [ratingRange, setRatingRange] = useState<[number, number]>([0, 4000])
+  const [activeTab, setActiveTab] = useState<"same" | "all">("same")
+
+  const { data, isLoading } = useSWR<{
+    leaderboard: LeaderboardEntry[]
+  }>(`/api/leaderboards?type=${activeTab}&ratingMin=${ratingRange[0]}&ratingMax=${ratingRange[1]}`, fetcher)
+
+  const getRankIcon = (rank: number) => {
+    switch (rank) {
+      case 1:
+        return <Trophy className="h-5 w-5 text-yellow-500" />
+      case 2:
+        return <Medal className="h-5 w-5 text-gray-400" />
+      case 3:
+        return <Award className="h-5 w-5 text-amber-600" />
+      default:
+        return <span className="text-sm font-medium text-muted-foreground">#{rank}</span>
+    }
+  }
+
+  const getRatingColor = (rating: number) => {
+    if (rating >= 2400) return 'text-red-500'      // Grandmaster
+    if (rating >= 2100) return 'text-orange-500'   // Master
+    if (rating >= 1900) return 'text-purple-500'   // Candidate Master
+    if (rating >= 1600) return 'text-blue-500'     // Expert
+    if (rating >= 1400) return 'text-cyan-500'     // Specialist
+    if (rating >= 1200) return 'text-green-500'    // Pupil
+    return 'text-gray-500'                          // Newbie
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="h-5 w-5" />
+              Leaderboards
+            </CardTitle>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue="same" onValueChange={(value) => setActiveTab(value as "same" | "all")} className="space-y-6">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="same">Same College</TabsTrigger>
+            <TabsTrigger value="all">All Colleges</TabsTrigger>
+          </TabsList>
+
+          <div className="space-y-4">
+            <div>
+              <label className="text-sm font-medium">Rating Filter: {ratingRange[0]} - {ratingRange[1]}</label>
+              <Slider
+                value={ratingRange}
+                onValueChange={(value) => setRatingRange(value as [number, number])}
+                max={4000}
+                min={0}
+                step={100}
+                className="mt-2"
+              />
+            </div>
+          </div>
+
+          <TabsContent value="same" className="mt-6">
+            {isLoading ? (
+              <div className="space-y-3">
+                {[1, 2, 3, 4, 5].map(i => (
+                  <div key={i} className="flex items-center space-x-4 p-3 bg-muted/20 rounded-lg animate-pulse">
+                    <div className="h-10 w-10 bg-muted rounded-full" />
+                    <div className="flex-1">
+                      <div className="h-4 bg-muted rounded w-24 mb-2" />
+                      <div className="h-3 bg-muted rounded w-16" />
+                    </div>
+                    <div className="h-6 bg-muted rounded w-12" />
+                  </div>
+                ))}
+              </div>
+            ) : data?.leaderboard ? (
+              <div className="space-y-2">
+                {data.leaderboard.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className={`flex items-center space-x-4 p-3 rounded-lg transition-colors hover:bg-muted/20 ${
+                      entry.rank <= 3 ? 'bg-muted/10 border border-muted' : ''
+                    }`}
+                  >
+                    <div className="flex items-center justify-center w-8">
+                      {getRankIcon(entry.rank)}
+                    </div>
+
+                    <Avatar className="h-10 w-10">
+                      <AvatarFallback>{entry.name.substring(0, 2).toUpperCase()}</AvatarFallback>
+                    </Avatar>
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-medium truncate">{entry.name}</p>
+                        <Badge variant="outline" className="text-xs">
+                          {entry.handle}
+                        </Badge>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {entry.college}
+                      </p>
+                    </div>
+
+                    <div className="text-right">
+                      <p className={`text-sm font-semibold ${getRatingColor(entry.rating)}`}>
+                        {entry.rating}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-8">
+                <Users className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+                <p className="text-sm text-muted-foreground">No members found</p>
+              </div>
+            )}
+          </TabsContent>
+
+          <TabsContent value="all" className="mt-6">
+            {isLoading ? (
+              <div className="space-y-3">
+                {[1, 2, 3, 4, 5].map(i => (
+                  <div key={i} className="flex items-center space-x-4 p-3 bg-muted/20 rounded-lg animate-pulse">
+                    <div className="h-10 w-10 bg-muted rounded-full" />
+                    <div className="flex-1">
+                      <div className="h-4 bg-muted rounded w-24 mb-2" />
+                      <div className="h-3 bg-muted rounded w-16" />
+                    </div>
+                    <div className="h-6 bg-muted rounded w-12" />
+                  </div>
+                ))}
+              </div>
+            ) : data?.leaderboard ? (
+              <div className="space-y-2">
+                {data.leaderboard.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className={`flex items-center space-x-4 p-3 rounded-lg transition-colors hover:bg-muted/20 ${
+                      entry.rank <= 3 ? 'bg-muted/10 border border-muted' : ''
+                    }`}
+                  >
+                    <div className="flex items-center justify-center w-8">
+                      {getRankIcon(entry.rank)}
+                    </div>
+
+                    <Avatar className="h-10 w-10">
+                      <AvatarFallback>{entry.name.substring(0, 2).toUpperCase()}</AvatarFallback>
+                    </Avatar>
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-medium truncate">{entry.name}</p>
+                        <Badge variant="outline" className="text-xs">
+                          {entry.handle}
+                        </Badge>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {entry.college}
+                      </p>
+                    </div>
+
+                    <div className="text-right">
+                      <p className={`text-sm font-semibold ${getRatingColor(entry.rating)}`}>
+                        {entry.rating}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-8">
+                <Users className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+                <p className="text-sm text-muted-foreground">No members found</p>
+              </div>
+            )}
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/codeforces-api.ts
+++ b/lib/codeforces-api.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto'
+import crypto from "crypto";
 
 /**
  * Codeforces API utility with authentication
@@ -6,426 +6,148 @@ import crypto from 'crypto'
  */
 
 interface CFApiResponse<T = any> {
-  status: 'OK' | 'FAILED'
-  comment?: string
-  result?: T
+  status: "OK" | "FAILED";
+  comment?: string;
+  result?: T;
 }
 
-/**
- * Generate authenticated Codeforces API URL
- * @param method - API method (e.g., 'user.info', 'user.rating')
- * @param params - Additional parameters
- * @returns Authenticated URL with signature
- */
-function generateAuthenticatedUrl(method: string, params: Record<string, string> = {}): string {
-  const apiKey = process.env.CODEFORCES_API_KEY
-  const apiSecret = process.env.CODEFORCES_API_SECRET
+export interface CodeforcesUser {
+  handle: string;
+  rating?: number;
+  maxRating?: number;
+  rank?: string;
+  maxRank?: string;
+  registrationTimeSeconds: number;
+  avatar?: string;
+  firstName?: string;
+  lastName?: string;
+  country?: string;
+  city?: string;
+  organization?: string;
+}
+
+// --- Authenticated URL generator ---
+function generateAuthenticatedUrl(
+  method: string,
+  params: Record<string, string> = {}
+): string {
+  const apiKey = process.env.CODEFORCES_API_KEY;
+  const apiSecret = process.env.CODEFORCES_API_SECRET;
 
   if (!apiKey || !apiSecret) {
-    console.warn('Codeforces API credentials not configured, using public API')
-    // Return public API URL without authentication
-    const queryParams = new URLSearchParams(params)
-    return `https://codeforces.com/api/${method}?${queryParams}`
+    console.warn("Codeforces API credentials not configured, using public API");
+    const queryParams = new URLSearchParams(params);
+    return `https://codeforces.com/api/${method}?${queryParams}`;
   }
 
-  // Generate timestamp
-  const time = Math.floor(Date.now() / 1000)
-  
-  // Prepare parameters
+  const time = Math.floor(Date.now() / 1000);
+
   const allParams: Record<string, string> = {
     ...params,
     apiKey,
-    time: time.toString()
-  }
+    time: time.toString(),
+  };
 
-  // Sort parameters by key
   const sortedParams = Object.keys(allParams)
     .sort()
-    .map(key => `${key}=${allParams[key]}`)
-    .join('&')
+    .map((key) => `${key}=${allParams[key]}`)
+    .join("&");
 
-  // Generate signature
-  const rand = crypto.randomBytes(6).toString('hex')
-  const toSign = `${rand}/${method}?${sortedParams}#${apiSecret}`
-  const signature = crypto.createHash('sha512').update(toSign).digest('hex')
+  const rand = crypto.randomBytes(6).toString("hex");
+  const toSign = `${rand}/${method}?${sortedParams}#${apiSecret}`;
+  const signature = crypto.createHash("sha512").update(toSign).digest("hex");
 
-  // Build final URL
   const finalParams = new URLSearchParams({
     ...allParams,
-    apiSig: `${rand}${signature}`
-  })
+    apiSig: `${rand}${signature}`,
+  });
 
-  return `https://codeforces.com/api/${method}?${finalParams}`
+  return `https://codeforces.com/api/${method}?${finalParams}`;
 }
 
-/**
- * Make authenticated request to Codeforces API
- * @param method - API method
- * @param params - Parameters
- * @returns API response
- */
+// --- Generic request ---
 export async function cfApiRequest<T = any>(
-  method: string, 
+  method: string,
   params: Record<string, string> = {}
 ): Promise<CFApiResponse<T>> {
-  const url = generateAuthenticatedUrl(method, params)
-  
+  const url = generateAuthenticatedUrl(method, params);
+
   try {
     const response = await fetch(url, {
-      cache: 'no-store',
-      headers: {
-        'User-Agent': 'AlgoRise/1.0'
-      }
-    })
+      cache: "no-store",
+      headers: { "User-Agent": "AlgoRise/1.0" },
+    });
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
 
-    const data = await response.json()
-    return data as CFApiResponse<T>
+    return (await response.json()) as CFApiResponse<T>;
   } catch (error) {
-    console.error(`Codeforces API error for ${method}:`, error)
+    console.error(`Codeforces API error for ${method}:`, error);
     return {
-      status: 'FAILED',
-      comment: error instanceof Error ? error.message : 'Unknown error'
-    }
+      status: "FAILED",
+      comment: error instanceof Error ? error.message : "Unknown error",
+    };
   }
 }
 
-/**
- * Get user info from Codeforces
- * @param handles - Comma-separated list of handles
- */
-export async function cfGetUserInfo(handles: string) {
-  // Use public API for user info (more reliable)
-  const url = `https://codeforces.com/api/user.info?handles=${handles}`
-  
+// --- Specific endpoints ---
+export async function cfGetUserInfo(
+  handles: string
+): Promise<CFApiResponse<CodeforcesUser[]>> {
+  const url = `https://codeforces.com/api/user.info?handles=${handles}`;
   try {
     const response = await fetch(url, {
-      cache: 'no-store',
-      headers: {
-        'User-Agent': 'AlgoRise/1.0'
-      }
-    })
-
+      cache: "no-store",
+      headers: { "User-Agent": "AlgoRise/1.0" },
+    });
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
-
-    const data = await response.json()
-    return data as CFApiResponse
+    return (await response.json()) as CFApiResponse<CodeforcesUser[]>;
   } catch (error) {
-    console.error(`Codeforces user.info API error for ${handles}:`, error)
+    console.error(`Codeforces user.info API error for ${handles}:`, error);
     return {
-      status: 'FAILED',
-      comment: error instanceof Error ? error.message : 'Unknown error'
-    }
+      status: "FAILED",
+      comment: error instanceof Error ? error.message : "Unknown error",
+    };
   }
 }
 
-/**
- * Get user rating history from Codeforces
- * @param handle - User handle
- */
-export async function cfGetUserRating(handle: string) {
-  // Use public API for better reliability
-  const url = `https://codeforces.com/api/user.rating?handle=${handle}`
-  
-  try {
-    const response = await fetch(url, {
-      cache: 'no-store',
-      headers: {
-        'User-Agent': 'AlgoRise/1.0'
+// --- Batch user ratings ---
+export async function getUserRatings(
+  handles: string[]
+): Promise<
+  Record<string, { rating: number; maxRating: number; rank: string }>
+> {
+  const ratings: Record<
+    string,
+    { rating: number; maxRating: number; rank: string }
+  > = {};
+
+  const batchSize = 10;
+  for (let i = 0; i < handles.length; i += batchSize) {
+    const batch = handles.slice(i, i + batchSize);
+
+    try {
+      const response = await cfGetUserInfo(batch.join(","));
+      if (response.status === "OK" && response.result) {
+        response.result.forEach((user) => {
+          ratings[user.handle] = {
+            rating: user.rating ?? 1200,
+            maxRating: user.maxRating ?? 1200,
+            rank: user.rank ?? "Unrated",
+          };
+        });
       }
-    })
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-    }
-
-    const data = await response.json()
-    return data as CFApiResponse
-  } catch (error) {
-    console.error(`Codeforces user.rating API error for ${handle}:`, error)
-    return {
-      status: 'FAILED',
-      comment: error instanceof Error ? error.message : 'Unknown error'
+    } catch (err) {
+      console.error(`Batch failed for handles: ${batch.join(",")}`, err);
+      batch.forEach((h) => {
+        ratings[h] = { rating: 1200, maxRating: 1200, rank: "Unrated" };
+      });
     }
   }
-}
 
-/**
- * Get user status (submissions) from Codeforces
- * @param handle - User handle
- * @param from - Start index (optional)
- * @param count - Number of submissions (optional, max 100000)
- */
-export async function cfGetUserStatus(handle: string, from?: number, count?: number) {
-  // Use public API for better reliability
-  const params = new URLSearchParams({ handle })
-  if (from !== undefined) params.set('from', from.toString())
-  if (count !== undefined) params.set('count', count.toString())
-  
-  const url = `https://codeforces.com/api/user.status?${params.toString()}`
-  
-  try {
-    const response = await fetch(url, {
-      cache: 'no-store',
-      headers: {
-        'User-Agent': 'AlgoRise/1.0'
-      }
-    })
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-    }
-
-    const data = await response.json()
-    return data as CFApiResponse
-  } catch (error) {
-    console.error(`Codeforces user.status API error for ${handle}:`, error)
-    return {
-      status: 'FAILED',
-      comment: error instanceof Error ? error.message : 'Unknown error'
-    }
-  }
-}
-
-/**
- * Get contest list from Codeforces
- * @param gym - Include gym contests (optional)
- */
-export async function cfGetContestList(gym: boolean = false) {
-  // Use public API directly for contest list
-  const url = `https://codeforces.com/api/contest.list${gym ? '?gym=true' : ''}`
-  
-  try {
-    const response = await fetch(url, {
-      cache: 'no-store',
-      headers: {
-        'User-Agent': 'AlgoRise/1.0'
-      }
-    })
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-    }
-
-    const data = await response.json()
-    return data as CFApiResponse
-  } catch (error) {
-    console.error('Codeforces contest.list API error:', error)
-    return {
-      status: 'FAILED',
-      comment: error instanceof Error ? error.message : 'Unknown error'
-    }
-  }
-}
-
-/**
- * Get problems from contests
- * @param tags - Problem tags (optional)
- * @param problemsetName - Problemset name (optional)
- */
-export async function cfGetProblems(tags?: string[], problemsetName?: string) {
-  // Build URL for public API
-  const params = new URLSearchParams()
-  if (tags && tags.length > 0) params.set('tags', tags.join(';'))
-  if (problemsetName) params.set('problemsetName', problemsetName)
-  
-  const url = `https://codeforces.com/api/problemset.problems${params.toString() ? '?' + params.toString() : ''}`
-  
-  try {
-    const response = await fetch(url, {
-      cache: 'no-store',
-      headers: {
-        'User-Agent': 'AlgoRise/1.0'
-      }
-    })
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-    }
-
-    const data = await response.json()
-    return data as CFApiResponse
-  } catch (error) {
-    console.error('Codeforces problemset.problems API error:', error)
-    return {
-      status: 'FAILED',
-      comment: error instanceof Error ? error.message : 'Unknown error'
-    }
-  }
-}
-
-/**
- * Verify if API credentials are working
- */
-export async function cfTestConnection(): Promise<boolean> {
-  try {
-    const response = await cfGetUserInfo('tourist') // Test with a known user
-    return response.status === 'OK'
-  } catch {
-    return false
-  }
-}
-
-// Type definitions for better type safety
-export interface CodeforcesUser {
-  handle: string
-  rating?: number
-  maxRating?: number
-  rank?: string
-  maxRank?: string
-  registrationTimeSeconds: number
-  avatar?: string
-  firstName?: string
-  lastName?: string
-  country?: string
-  city?: string
-  organization?: string
-}
-
-export interface CodeforcesProblem {
-  contestId: number
-  index: string
-  name: string
-  type: string
-  points?: number
-  rating?: number
-  tags: string[]
-}
-
-export interface CodeforcesSubmission {
-  id: number
-  contestId: number
-  creationTimeSeconds: number
-  relativeTimeSeconds: number
-  problem: CodeforcesProblem
-  author: {
-    contestId?: number
-    members: Array<{ handle: string }>
-    participantType: string
-    ghost: boolean
-    room?: number
-    startTimeSeconds?: number
-  }
-  programmingLanguage: string
-  verdict?: string
-  testset: string
-  passedTestCount: number
-  timeConsumedMillis: number
-  memoryConsumedBytes: number
-}
-
-export interface CodeforcesContest {
-  id: number
-  name: string
-  type: string
-  phase: string
-  frozen: boolean
-  durationSeconds: number
-  startTimeSeconds?: number
-  relativeTimeSeconds?: number
-}
-
-// Helper functions for adaptive practice
-export function getUpcomingContests(contests: CodeforcesContest[]): CodeforcesContest[] {
-  const now = Math.floor(Date.now() / 1000)
-  return contests.filter(contest => 
-    contest.phase === 'BEFORE' && 
-    contest.startTimeSeconds && 
-    contest.startTimeSeconds > now
-  ).sort((a, b) => (a.startTimeSeconds || 0) - (b.startTimeSeconds || 0))
-}
-
-export function getSolvedProblems(submissions: CodeforcesSubmission[]): Set<string> {
-  const solved = new Set<string>()
-  submissions.forEach(submission => {
-    if (submission.verdict === 'OK') {
-      solved.add(`${submission.problem.contestId}${submission.problem.index}`)
-    }
-  })
-  return solved
-}
-
-export function getAdaptiveProblems(
-  problems: CodeforcesProblem[], 
-  userRating: number,
-  solvedProblems: Set<string>,
-  count: number = 10
-): CodeforcesProblem[] {
-  // Adaptive range: user rating - 100 to user rating + 200
-  const minRating = Math.max(800, userRating - 100) // Minimum 800
-  const maxRating = userRating + 200
-  
-  const suitable = problems.filter(problem => 
-    problem.rating && 
-    problem.rating >= minRating && 
-    problem.rating <= maxRating &&
-    !solvedProblems.has(`${problem.contestId}${problem.index}`)
-  )
-  
-  // Shuffle and return requested count
-  const shuffled = suitable.sort(() => Math.random() - 0.5)
-  return shuffled.slice(0, count)
-}
-
-export function calculateUserProgress(submissions: CodeforcesSubmission[]): {
-  totalSolved: number
-  byDifficulty: Record<string, number>
-  byTags: Record<string, number>
-  recentActivity: Array<{ date: string; count: number }>
-} {
-  const solved = getSolvedProblems(submissions)
-  const solvedSubmissions = submissions.filter(sub => 
-    sub.verdict === 'OK' && 
-    solved.has(`${sub.problem.contestId}${sub.problem.index}`)
-  )
-  
-  const byDifficulty: Record<string, number> = {}
-  const byTags: Record<string, number> = {}
-  const dailyActivity: Record<string, number> = {}
-  
-  solvedSubmissions.forEach(submission => {
-    // Count by difficulty
-    const rating = submission.problem.rating || 0
-    const difficulty = getRatingCategory(rating)
-    byDifficulty[difficulty] = (byDifficulty[difficulty] || 0) + 1
-    
-    // Count by tags
-    submission.problem.tags.forEach(tag => {
-      byTags[tag] = (byTags[tag] || 0) + 1
-    })
-    
-    // Daily activity
-    const date = new Date(submission.creationTimeSeconds * 1000).toDateString()
-    dailyActivity[date] = (dailyActivity[date] || 0) + 1
-  })
-  
-  // Convert daily activity to array format
-  const recentActivity = Object.entries(dailyActivity)
-    .map(([date, count]) => ({ date, count }))
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-    .slice(0, 30) // Last 30 days
-  
-  return {
-    totalSolved: solved.size,
-    byDifficulty,
-    byTags,
-    recentActivity
-  }
-}
-
-function getRatingCategory(rating: number): string {
-  if (rating < 1000) return 'Beginner'
-  if (rating < 1200) return 'Newbie'
-  if (rating < 1400) return 'Pupil'
-  if (rating < 1600) return 'Specialist'
-  if (rating < 1900) return 'Expert'
-  if (rating < 2100) return 'Candidate Master'
-  if (rating < 2300) return 'Master'
-  if (rating < 2400) return 'International Master'
-  return 'Grandmaster'
+  return ratings;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@radix-ui/react-tooltip": "latest",
         "@remix-run/react": "latest",
         "@supabase/ssr": "latest",
-        "@supabase/supabase-js": "latest",
+        "@supabase/supabase-js": "^2.58.0",
         "@vercel/analytics": "^1.3.2",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
@@ -67,7 +67,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.9",
-        "@types/node": "^22",
+        "@types/node": "^22.18.6",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "postcss": "^8.5",
@@ -2221,18 +2221,18 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.71.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
-      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "version": "2.72.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.72.0.tgz",
+      "integrity": "sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
-      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.5.0.tgz",
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
@@ -2251,18 +2251,18 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.3.tgz",
-      "integrity": "sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==",
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.4.tgz",
-      "integrity": "sha512-e/FYIWjvQJHOCNACWehnKvg26zosju3694k0NMUNb+JGLdvHJzEa29ZVVLmawd2kvx4hdbv8mxSqfttRnH3+DA==",
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.13",
@@ -2293,26 +2293,26 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.11.0.tgz",
-      "integrity": "sha512-Y+kx/wDgd4oasAgoAq0bsbQojwQ+ejIif8uczZ9qufRHWFLMU5cODT+ApHsSrDufqUcVKt+eyxtOXSkeh2v9ww==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.2.tgz",
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.57.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.0.tgz",
-      "integrity": "sha512-h9ttcL0MY4h+cGqZl95F/RuqccuRBjHU9B7Qqvw0Da+pPK2sUlU1/UdvyqUGj37UsnSphr9pdGfeXjesYkBcyA==",
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.58.0.tgz",
+      "integrity": "sha512-Tm1RmQpoAKdQr4/8wiayGti/no+If7RtveVZjHR8zbO7hhQjmPW2Ok5ZBPf1MGkt5c+9R85AVMsTfSaqAP1sUg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.71.1",
-        "@supabase/functions-js": "2.4.5",
+        "@supabase/auth-js": "2.72.0",
+        "@supabase/functions-js": "2.5.0",
         "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.21.3",
-        "@supabase/realtime-js": "2.15.4",
-        "@supabase/storage-js": "^2.10.4"
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.2"
       }
     },
     "node_modules/@swc/helpers": {
@@ -2670,9 +2670,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
-      "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+      "version": "22.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
+      "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@radix-ui/react-tooltip": "latest",
     "@remix-run/react": "latest",
     "@supabase/ssr": "latest",
-    "@supabase/supabase-js": "latest",
+    "@supabase/supabase-js": "^2.58.0",
     "@vercel/analytics": "^1.3.2",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.9",
-    "@types/node": "^22",
+    "@types/node": "^22.18.6",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "postcss": "^8.5",

--- a/scripts/009_add_college_to_profiles.sql
+++ b/scripts/009_add_college_to_profiles.sql
@@ -1,0 +1,16 @@
+-- Add college_id to profiles table
+ALTER TABLE profiles 
+ADD COLUMN IF NOT EXISTS college_id UUID REFERENCES colleges(id) ON DELETE SET NULL;
+ALTER TABLE group_memberships 
+ADD CONSTRAINT check_college_match 
+CHECK (
+  CASE 
+    WHEN (SELECT g.type FROM groups g WHERE g.id = group_id) = 'college' THEN
+      (SELECT p.college_id FROM profiles p WHERE p.id = user_id) = (SELECT g.college_id FROM groups g WHERE g.id = group_id)
+    ELSE true 
+  END
+);
+
+-- Index for performance
+CREATE INDEX IF NOT EXISTS idx_profiles_college_id ON profiles(college_id);
+CREATE INDEX IF NOT EXISTS idx_group_memberships_college ON group_memberships(group_id) WHERE (SELECT g.type FROM groups g WHERE g.id = group_id) = 'college';


### PR DESCRIPTION
…with same/all colleges tabs, and group creation/validation rules

Signup Flow: OAuth sign-in → CF handle verification → College selection → Dashboard redirect
Leaderboards: Loading global leaderboards, Same College/All Colleges tabs, rating filters, live CF ratings display
Group Creation: Creating college-enforced groups, adding members with college validation, max 3 members enforcement
Invite System: Generating shareable invite links, joining via codes with college checks
Edge Cases: Custom college creation, different college rejection, full group errors