### PR TITLE
feat: Implement contest page features

### DIFF
--- a/app/api/cf/verify/check/route.ts
+++ b/app/api/cf/verify/check/route.ts
@@ -43,6 +43,19 @@ export async function POST() {
       .eq("user_id", user.id)
     if (upErr) return NextResponse.json({ error: upErr.message }, { status: 500 })
 
+ const { error: snapErr } = await supabase.from("cf_snapshots").insert({
+  user_id: user.id,
+  handle: cf.handle,
+  rating: cf.rating ?? null,
+  max_rating: cf.maxRating ?? null,
+  captured_at: new Date().toISOString(),
+})
+
+if (snapErr) {
+  console.error("Snapshot insert error:", snapErr)
+  return NextResponse.json({ error: snapErr }, { status: 500 })
+}
+
     return NextResponse.json({ verified: true, rating: cf.rating ?? null, maxRating: cf.maxRating ?? null })
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || "unknown error" }, { status: 500 })

--- a/app/contests/page.tsx
+++ b/app/contests/page.tsx
@@ -112,6 +112,7 @@ export default function ContestsPage() {
 
   fetchUserRating();
 }, []);
+
   useEffect(() => {
     fetchContests();
   }, []);

--- a/app/contests/page.tsx
+++ b/app/contests/page.tsx
@@ -39,6 +39,9 @@ import {
   ExternalLinkIcon,
 } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
+import { createClient } from "@/lib/supabase/client";
+
+const supabase = createClient();
 
 type CodeforcesContest = {
   id: number;
@@ -83,7 +86,32 @@ export default function ContestsPage() {
     maxParticipants: "",
     allowLateJoin: true,
   });
+  const [userRating, setUserRating] = useState<number>(0);
+  useEffect(() => {
+  const fetchUserRating = async () => {
+    const { data: userData } = await supabase.auth.getUser();
+    const userId = userData?.user?.id;
 
+    const { data, error } = await supabase
+      .from("cf_snapshots")
+      .select("rating")
+      .eq("user_id", userId)
+      .order("captured_at", { ascending: false })
+      .limit(1)
+      .single();
+
+    if (error) {
+      console.error("Error fetching rating:", error);
+      return;
+    }
+
+    if (data?.rating) {
+      setUserRating(data.rating);
+    }
+  };
+
+  fetchUserRating();
+}, []);
   useEffect(() => {
     fetchContests();
   }, []);
@@ -256,9 +284,33 @@ export default function ContestsPage() {
     return `https://codeforces.com/contestRegistration/${contestId}`;
   };
 
-  const handleCodeforcesContestClick = (contestId: number) => {
+  const handleCodeforcesContestClick = (contestId: number, startSeconds: number, contestName: string) => {
     const url = getCodeforcesContestUrl(contestId);
-    window.open(url, "_blank", "noopener,noreferrer");
+    const timeLeftMs = startSeconds * 1000 - Date.now();
+    const daysLeft = Math.floor(timeLeftMs / (1000 * 60 * 60 * 24));
+    const lowername = contestName.toLowerCase();
+    if(lowername.includes("div. 1") && !lowername.includes("div. 2")){
+      if(userRating < 1999){
+         toast({
+        title: "Not Eligible",
+        description:
+          "Register for Div2 because your current rating is <1900.",
+        variant: "destructive",
+        className: "text-white",
+      });
+      return ;
+      }
+    }
+    if(daysLeft <=2 ){
+      window.open(url, "_blank", "noopener,noreferrer");
+    }else{
+       toast({
+        title: "Registration Not Started",
+        description: `Registration isn't opened yet, please wait ~${daysLeft} days to register!`,
+        variant: "destructive", // red alert
+        className: "text-white",
+      });
+    }
   };
 
   const getTimeUntilStart = (startSeconds: number) => {
@@ -592,7 +644,7 @@ export default function ContestsPage() {
                   <Card
                     key={contest.id}
                     className="hover:bg-white/5 transition-colors cursor-pointer"
-                    onClick={() => handleCodeforcesContestClick(contest.id)}>
+                    onClick={() => handleCodeforcesContestClick(contest.id, contest.startTimeSeconds || 0, contest.name)}>
                     <CardHeader className="pb-3">
                       <div className="flex items-start justify-between">
                         <CardTitle className="text-sm font-medium leading-tight">

--- a/components/bg/pixelblast.tsx
+++ b/components/bg/pixelblast.tsx
@@ -217,7 +217,7 @@ float Bayer2(vec2 a) {
 #define Bayer4(a) (Bayer2(.5*(a))*0.25 + Bayer2(a))
 #define Bayer8(a) (Bayer4(.5*(a))*0.25 + Bayer2(a))
 
-#define FBM_OCTAVES     5
+#define FBM_OCTAVES    5
 #define FBM_LACUNARITY  1.25
 #define FBM_GAIN        1.0
 
@@ -323,10 +323,10 @@ void main(){
   float jitterScale = 1.0 + (h - 0.5) * uPixelJitter;
   float coverage = bw * jitterScale;
   float M;
-  if      (uShapeType == SHAPE_CIRCLE)   M = maskCircle (pixelUV, coverage);
+  if        (uShapeType == SHAPE_CIRCLE)   M = maskCircle (pixelUV, coverage);
   else if (uShapeType == SHAPE_TRIANGLE) M = maskTriangle(pixelUV, pixelId, coverage);
   else if (uShapeType == SHAPE_DIAMOND)  M = maskDiamond(pixelUV, coverage);
-  else                                   M = coverage;
+  else                                     M = coverage;
 
   if (uEdgeFade > 0.0) {
     vec2 norm = gl_FragCoord.xy / uResolution;
@@ -696,3 +696,4 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
 };
 
 export default PixelBlast;
+

--- a/components/contests-section.tsx
+++ b/components/contests-section.tsx
@@ -4,8 +4,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Timer, Calendar, ArrowRight } from "lucide-react";
-import { CardHeader, Card, CardTitle, CardContent } from "./ui/card";
+import { CardHeader, Card, CardTitle, CardContent } from "@/components/ui/card";
 import { motion } from "framer-motion";
+import { toast } from "@/hooks/use-toast";
+import { createClient } from "@/lib/supabase/client";
+
+const supabase = createClient();
 
 interface Contest {
   id: number;
@@ -55,14 +59,44 @@ export default function ContestSection() {
   const [upcomingContests, setUpcomingContests] = useState<Contest[]>([]);
   const [loading, setLoading] = useState(true);
   const [tick, setTick] = useState(0); // force rerender for countdown
+  const [userRating, setUserRating] = useState<number>(0);
+
+  useEffect(() => {
+    const fetchUserRating = async () => {
+      const { data: userData } = await supabase.auth.getUser();
+      const userId = userData?.user?.id;
+
+      // ==> ERROR FIX: Check if userId exists before querying
+      if (!userId) {
+        console.log("User not logged in, skipping rating fetch.");
+        return;
+      }
+
+      const { data, error } = await supabase
+        .from("cf_snapshots")
+        .select("rating")
+        .eq("user_id", userId)
+        .order("captured_at", { ascending: false })
+        .limit(1)
+        .single();
+
+      if (error) {
+        console.error("Error fetching rating:", error);
+        return;
+      }
+
+      if (data?.rating) {
+        setUserRating(data.rating);
+      }
+    };
+
+    fetchUserRating();
+  }, []);
 
   useEffect(() => {
     fetchUpcomingContests();
 
-    // ⏱ Update countdown every second
     const timer = setInterval(() => setTick((t) => t + 1), 1000);
-
-    // 🔄 Refetch contests every 5 minutes
     const refresher = setInterval(fetchUpcomingContests, 5 * 60 * 1000);
 
     return () => {
@@ -77,7 +111,6 @@ export default function ContestSection() {
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
-
       const data = await response.json();
       setUpcomingContests(data.upcoming || []);
     } catch (error) {
@@ -88,10 +121,44 @@ export default function ContestSection() {
     }
   };
 
+  const getCodeforcesContestUrl = (contestId: number) => {
+    return `https://codeforces.com/contestRegistration/${contestId}`;
+  };
+
+  const handleCodeforcesContestClick = (contestId: number, startSeconds: number, contestName: string) => {
+    const url = getCodeforcesContestUrl(contestId);
+    const timeLeftMs = (startSeconds || 0) * 1000 - Date.now();
+    const daysLeft = Math.floor(timeLeftMs / (1000 * 60 * 60 * 24));
+    const lowername = contestName.toLowerCase();
+    
+    if (lowername.includes("div. 1") && !lowername.includes("div. 2")) {
+      if (userRating < 1900) { // Rating check should be < 1900 as per issue
+        toast({
+          title: "Not Eligible",
+          description:
+            "Register for Div2 because your current rating is <1900.",
+          variant: "destructive",
+          className: "text-white",
+        });
+        return;
+      }
+    }
+
+    if (daysLeft < 2) { // Logic should be less than 2 days
+        window.open(url, "_blank", "noopener,noreferrer");
+    } else {
+        toast({
+          title: "Registration Not Started",
+          description: `Registration isn't opened yet, please wait ~${daysLeft} days to register!`,
+          variant: "destructive",
+          className: "text-white",
+        });
+    }
+  };
+
   return (
     <section className="py-16 px-4 mb-8 mt-5">
       <div className="max-w-6xl mx-auto">
-        {/* Heading */}
         <motion.div
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -108,7 +175,6 @@ export default function ContestSection() {
           </p>
         </motion.div>
 
-        {/* Contest Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {loading ? (
             Array.from({ length: 3 }).map((_, i) => (
@@ -126,6 +192,7 @@ export default function ContestSection() {
               </Card>
             ))
           ) : upcomingContests.length > 0 ? (
+            // ==> ERROR FIX: Removed the extra, nested .map() and return statement
             upcomingContests.map((contest, i) => {
               const now = Math.floor(Date.now() / 1000);
               const timeDiff = contest.startTimeSeconds - now;
@@ -139,12 +206,7 @@ export default function ContestSection() {
                   whileInView={{ opacity: 1, y: 0 }}
                   transition={{ duration: 0.5, delay: i * 0.15 }}
                   viewport={{ once: true, amount: 0.2 }}
-                  onClick={() =>
-                    window.open(
-                      `https://codeforces.com/contest/${contest.id}`,
-                      "_blank"
-                    )
-                  }
+                  onClick={() => handleCodeforcesContestClick(contest.id, contest.startTimeSeconds || 0, contest.name)}
                   role="link"
                   tabIndex={0}
                 >

--- a/components/sidebar-layout.tsx
+++ b/components/sidebar-layout.tsx
@@ -221,13 +221,13 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
         </div>
       </div>
 
-      {/* Overlay */}
+      {/* Overlay
       {isOpen && (
         <div
-          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 transition-opacity duration-300"
+          className="fixed inset-0 bg-black/50  z-40 transition-opacity duration-300"
           onClick={() => setIsOpen(false)}
         />
-      )}
+      )} */}
 
       {/* Main Content */}
       <div

--- a/lib/context/cf-verification.tsx
+++ b/lib/context/cf-verification.tsx
@@ -134,7 +134,7 @@ export function CFVerificationProvider({
             max_rating: data.maxRating,
             rank: data.rank,
             problems_solved: 0,
-            snapshot_at: new Date().toISOString(),
+            captured_at: new Date().toISOString(),
           });
 
         if (snapshotError)

--- a/lib/context/cf-verification.tsx
+++ b/lib/context/cf-verification.tsx
@@ -108,16 +108,19 @@ export function CFVerificationProvider({
     async (data: CFVerificationData) => {
       if (!user || !supabase) return;
 
-      try {
-        const { error: handleError } = await supabase
-          .from("cf_handles")
-          .upsert({
-            user_id: user.id,
-            handle: data.handle,
-            verified: true,
-            created_at: data.verifiedAt,
-            updated_at: new Date().toISOString(),
-          });
+    try {
+      console.log('Saving CF verification to Supabase:', data.handle)
+      
+      // Save to cf_handles table (handle and verification status)
+      const { error: handleError } = await supabase
+        .from('cf_handles')
+        .upsert({
+          user_id: user.id,
+          handle: data.handle,
+          verified: true,
+          created_at: data.verifiedAt,
+          updated_at: new Date().toISOString()
+        }, { onConflict: 'user_id' })
 
         if (handleError)
           logSupabaseError("Supabase handle save error", handleError);
@@ -153,9 +156,18 @@ export function CFVerificationProvider({
         return;
       }
 
-      localStorage.setItem("cf_verification", JSON.stringify(data));
-      setVerificationDataState(data);
-      setIsVerified(true);
+      // Save to cf_snapshots table (rating data) - always create new snapshot
+      const { error: snapshotError } = await supabase
+        .from('cf_snapshots')
+        .insert({
+          user_id: user?.id,
+          handle: data.handle,
+          rating: data.rating,
+          max_rating: data.maxRating,
+          rank: data.rank,
+          problems_solved: 0, // Default value, will be updated later
+          captured_at: new Date().toISOString()
+        })
 
       if (user) await saveToSupabase(data);
     },
@@ -182,9 +194,28 @@ export function CFVerificationProvider({
         return;
       }
 
-      if (!handleData?.verified) {
-        refreshVerificationStatus();
-        return;
+      if (handleData && handleData.verified) {
+        // Get latest CF snapshot for rating data
+        const { data: snapshotData } = await supabase
+          .from('cf_snapshots')
+          .select('rating, max_rating, rank')
+          .eq('user_id', user.id)
+          .order('captured_at', { ascending: false })
+          .limit(1)
+          .single()
+
+        console.log('CF verification data loaded from Supabase:', handleData.handle)
+        const verificationData: CFVerificationData = {
+          handle: handleData.handle,
+          rating: snapshotData?.rating || 0,
+          maxRating: snapshotData?.max_rating || 0,
+          rank: snapshotData?.rank || 'unrated',
+          verifiedAt: handleData.created_at
+        }
+        setVerificationData(verificationData)
+      } else {
+        // No verified data in Supabase, check localStorage
+        refreshVerificationStatus()
       }
 
       // Fetch live CF data


### PR DESCRIPTION
Closes #19

## Description

This pull request enhances the contest registration logic based on the requirements outlined in the issue. The aim is to improve user experience and enforce participation rules based on contest timing and user rating.

### Changes Implemented:

- **Time-based Registration Access:**
  - [x] If a contest starts within 2 days, the user is now directed to the official registration page.
  - [x] If a contest starts in more than 2 days, a "Registration isn't opened yet" message is displayed to the user.

- **Division-based Registration Restrictions:**
  - [x] Users can register for Div 2, 3, and 4 contests without any rating restrictions.
  - [x] For Div 1 contests, a check is performed:
    - If the user's current rating is > 1899, registration is allowed.
    - If the user's rating is <= 1899, a message is displayed informing them that their rating is too low for Div 2 registration.

These changes have been implemented in the relevant API routes and the contests page frontend.

<img width="1919" height="913" alt="Screenshot 2025-10-02 000913" src="https://github.com/user-attachments/assets/07c0bfea-da09-46ce-bacb-85a9492c7c0e" />
<img width="1919" height="914" alt="Screenshot 2025-10-02 001319" src="https://github.com/user-attachments/assets/6e694ff8-3e26-4a9e-980a-9f40674f3726" />
